### PR TITLE
Simplify UI to grayscale palette

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,8 +13,8 @@
 
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-            background-color: #f5f7fa;
-            color: #333;
+            background-color: #f5f5f5;
+            color: #222;
         }
 
         .container {
@@ -24,7 +24,7 @@
         }
 
         header {
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            background: linear-gradient(135deg, #444 0%, #222 100%);
             color: white;
             padding: 30px 0;
             margin-bottom: 30px;
@@ -47,7 +47,7 @@
         .tab {
             flex: 1;
             padding: 15px 20px;
-            background: #f8f9fa;
+            background: #f4f4f4;
             border: none;
             cursor: pointer;
             font-size: 16px;
@@ -60,12 +60,12 @@
         }
 
         .tab:hover {
-            background: #e9ecef;
+            background: #e0e0e0;
         }
 
         .tab.active {
             background: white;
-            color: #667eea;
+            color: #222;
             font-weight: bold;
         }
 
@@ -94,7 +94,7 @@
         }
 
         .metric-card {
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            background: linear-gradient(135deg, #555 0%, #333 100%);
             color: white;
             padding: 20px;
             border-radius: 10px;
@@ -153,7 +153,7 @@
         }
 
         .btn {
-            background: #667eea;
+            background: #555;
             color: white;
             border: none;
             padding: 10px 20px;
@@ -165,24 +165,24 @@
         }
 
         .btn:hover {
-            background: #5a67d8;
+            background: #333;
             transform: translateY(-1px);
         }
 
         .btn-secondary {
-            background: #6c757d;
+            background: #666;
         }
 
         .btn-secondary:hover {
-            background: #5a6268;
+            background: #555;
         }
 
         .btn-success {
-            background: #28a745;
+            background: #222;
         }
 
         .btn-success:hover {
-            background: #218838;
+            background: #111;
         }
 
         /* Line allocation styles */
@@ -198,14 +198,14 @@
             gap: 20px;
             margin-bottom: 20px;
             padding: 15px;
-            background: #f8f9fa;
+            background: #f4f4f4;
             border-radius: 8px;
         }
 
         .chart-container {
             margin-top: 30px;
             padding: 20px;
-            background: #f8f9fa;
+            background: #f4f4f4;
             border-radius: 10px;
         }
 
@@ -220,13 +220,13 @@
 
         .progress-fill {
             height: 100%;
-            background: linear-gradient(90deg, #667eea 0%, #764ba2 100%);
+            background: linear-gradient(90deg, #555 0%, #333 100%);
             transition: width 0.3s;
         }
 
         .info-box {
-            background: #e8f4f8;
-            border-left: 4px solid #667eea;
+            background: #f4f4f4;
+            border-left: 4px solid #555;
             padding: 15px;
             margin: 20px 0;
             border-radius: 4px;
@@ -281,15 +281,15 @@
                         <h3>Wykorzystanie zasobów</h3>
                         <div class="value" id="resourceUtilization">0%</div>
                     </div>
-                    <div class="metric-card" style="background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);">
+                    <div class="metric-card" style="background: linear-gradient(135deg, #666 0%, #444 100%);">
                         <h3>Dostępne godziny</h3>
                         <div class="value"><span id="availableHours">0</span> <span class="unit">godz.</span></div>
                     </div>
-                    <div class="metric-card" style="background: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%);">
+                    <div class="metric-card" style="background: linear-gradient(135deg, #555 0%, #333 100%);">
                         <h3>Przepracowane godziny</h3>
                         <div class="value"><span id="workedHours">0</span> <span class="unit">godz.</span></div>
                     </div>
-                    <div class="metric-card" style="background: linear-gradient(135deg, #43e97b 0%, #38f9d7 100%);">
+                    <div class="metric-card" style="background: linear-gradient(135deg, #777 0%, #555 100%);">
                         <h3>Niewykorzystane</h3>
                         <div class="value"><span id="unusedHours">0</span> <span class="unit">godz.</span></div>
                     </div>


### PR DESCRIPTION
## Summary
- rework main stylesheet in **index.html** to use black, white, and gray tones
- adjust metric card backgrounds and button colors
- keep transitions for a modern feel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842bbbc77688327a1a676c9e43f1ebd